### PR TITLE
F: implement caching system with pokecache package

### DIFF
--- a/internal/pokeapi/client.go
+++ b/internal/pokeapi/client.go
@@ -3,16 +3,18 @@ package pokeapi
 import (
 	"net/http"
 	"time"
+
+	"github.com/Predator792002/PokiInfo/internal/pokecache"
 )
 
-// Client -
 type Client struct {
+	Cache      *pokecache.Cache // Add this field
 	httpClient http.Client
 }
 
-// NewClient -
-func NewClient(timeout time.Duration) Client {
+func NewClient(timeout, cacheInterval time.Duration) Client { // Two parameters now
 	return Client{
+		Cache: pokecache.NewCache(cacheInterval), // Create cache here
 		httpClient: http.Client{
 			Timeout: timeout,
 		},

--- a/internal/pokeapi/pokeapi.go
+++ b/internal/pokeapi/pokeapi.go
@@ -1,5 +1,5 @@
 package pokeapi
 
 const (
-	baseURL = "https://pokeapi.co/api/v2"
+	BaseURL = "https://pokeapi.co/api/v2"
 )

--- a/internal/pokecache/Cache.go
+++ b/internal/pokecache/Cache.go
@@ -1,0 +1,64 @@
+package pokecache
+
+import (
+	"sync"
+	"time"
+)
+
+type CacheEntry struct {
+	createdAt time.Time
+	val       []byte
+}
+
+type Cache struct {
+	cacheEntries map[string]CacheEntry
+	mu           *sync.Mutex
+}
+
+func (ch *Cache) Add(key string, val []byte) {
+	cache := CacheEntry{
+		createdAt: time.Now(),
+		val:       val,
+	}
+
+	ch.mu.Lock()
+	ch.cacheEntries[key] = cache
+	ch.mu.Unlock()
+}
+
+func (ch *Cache) Get(key string) ([]byte, bool) {
+	ch.mu.Lock()
+	value, ok := ch.cacheEntries[key]
+	ch.mu.Unlock()
+	if ok {
+		return value.val, true
+	} else {
+		return nil, false
+	}
+}
+
+func (ch *Cache) reapLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	for {
+		<-ticker.C
+		ch.mu.Lock()
+		for key, cache := range ch.cacheEntries {
+			timeSince := time.Since(cache.createdAt)
+			if timeSince > interval {
+				delete(ch.cacheEntries, key)
+			}
+		}
+		ch.mu.Unlock()
+	}
+}
+
+func NewCache(interval time.Duration) *Cache {
+	cacheEntries := make(map[string]CacheEntry)
+	var mtx sync.Mutex
+	newCh := Cache{
+		cacheEntries: cacheEntries,
+		mu:           &mtx,
+	}
+	go newCh.reapLoop(interval)
+	return &newCh
+}

--- a/internal/pokecache/pokecache_test.go
+++ b/internal/pokecache/pokecache_test.go
@@ -1,0 +1,61 @@
+package pokecache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestAddGet(t *testing.T) {
+	const interval = 5 * time.Second
+	cases := []struct {
+		key string
+		val []byte
+	}{
+		{
+			key: "https://example.com",
+			val: []byte("testdata"),
+		},
+		{
+			key: "https://example.com/path",
+			val: []byte("moretestdata"),
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Test case %v", i), func(t *testing.T) {
+			cache := NewCache(interval)
+			cache.Add(c.key, c.val)
+			val, ok := cache.Get(c.key)
+			if !ok {
+				t.Errorf("expected to find key")
+				return
+			}
+			if string(val) != string(c.val) {
+				t.Errorf("expected to find value")
+				return
+			}
+		})
+	}
+}
+
+func TestReapLoop(t *testing.T) {
+	const baseTime = 5 * time.Millisecond
+	const waitTime = baseTime + 5*time.Millisecond
+	cache := NewCache(baseTime)
+	cache.Add("https://example.com", []byte("testdata"))
+
+	_, ok := cache.Get("https://example.com")
+	if !ok {
+		t.Errorf("expected to find key")
+		return
+	}
+
+	time.Sleep(waitTime)
+
+	_, ok = cache.Get("https://example.com")
+	if ok {
+		t.Errorf("expected to not find key")
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,8 @@ import (
 )
 
 func main() {
-	pokeClient := pokeapi.NewClient(5 * time.Second)
+	pokeClient := pokeapi.NewClient(5*time.Minute, 5*time.Minute)
+
 	cfg := &config{
 		pokeapiClient: pokeClient,
 	}


### PR DESCRIPTION
- Add pokecache package with Cache struct and thread-safe operations
- Implement Add/Get methods with mutex protection for concurrent access
- Add automatic cleanup with reapLoop using time.Ticker
- Integrate cache into PokeAPI client to reduce HTTP requests
- Update map commands to check cache before making API calls
- Add comprehensive tests for cache functionality and expiration
- Export BaseURL constant from pokeapi package for reuse

Performance improvement: repeated map/mapb commands now use cached data