### PR TITLE
G: add explore command with cached location-area fetch

### DIFF
--- a/command_exit.go
+++ b/command_exit.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func commandExit(cfg *config) error {
+func commandExit(cfg *config, args []string) error {
 	fmt.Println("Closing the Pokedex... Goodbye!")
 	os.Exit(0)
 	return nil

--- a/command_explore.go
+++ b/command_explore.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func commandExplore(cfg *config, args []string) error {
+	if len(args) != 1 {
+		fmt.Println("usage: explore <area_name>")
+		return nil
+	}
+
+	area := strings.ToLower(strings.TrimSpace(args[0]))
+
+	fmt.Printf("Exploring %s...\n", area)
+	pokemons, err := cfg.pokeapiClient.GetPokemons(area)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Found Pokemon:")
+	for _, name := range pokemons {
+		fmt.Printf(" - %s\n", strings.ToLower(strings.TrimSpace(name)))
+	}
+	return nil
+}

--- a/command_help.go
+++ b/command_help.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-func commandHelp(cfg *config) error {
+func commandHelp(cfg *config, args []string) error {
 	fmt.Println()
 	fmt.Println("Welcome to the Pokedex!")
 	fmt.Println("Usage:")

--- a/command_map.go
+++ b/command_map.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Predator792002/PokiInfo/internal/pokeapi"
 )
 
-func commandMapf(cfg *config) error {
+func commandMapf(cfg *config, args []string) error {
 	url := pokeapi.BaseURL + "/location-area" // Default URL for first page
 	if cfg.nextLocationsURL != nil {
 		url = *cfg.nextLocationsURL
@@ -38,7 +38,7 @@ func commandMapf(cfg *config) error {
 	return nil
 }
 
-func commandMapb(cfg *config) error {
+func commandMapb(cfg *config, args []string) error {
 	if cfg.prevLocationsURL == nil {
 		return errors.New("you're on the first page")
 	}

--- a/internal/pokeapi/get_pokemons.go
+++ b/internal/pokeapi/get_pokemons.go
@@ -1,0 +1,58 @@
+package pokeapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func (c *Client) GetPokemons(pokeName string) ([]string, error) {
+	url := BaseURL + "/location-area" + "/" + pokeName
+
+	var dat []byte
+	cacheData, ok := c.Cache.Get(url)
+
+	if !ok {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case 200:
+			dat, err = io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			c.Cache.Add(url, dat)
+		case 404:
+			return nil, fmt.Errorf("pokemon Not found")
+		default:
+			return nil, fmt.Errorf("error producing response")
+		}
+
+	} else {
+		dat = cacheData
+	}
+
+	pokemonEncountersResp := Encounters{}
+	err := json.Unmarshal(dat, &pokemonEncountersResp)
+	if err != nil {
+		return nil, err
+	}
+
+	var pokemons []string
+
+	for _, enc := range pokemonEncountersResp.PokemonEncounters {
+		pokemons = append(pokemons, enc.Pokemon.Name)
+	}
+
+	return pokemons, nil
+
+}

--- a/internal/pokeapi/types_locations.go
+++ b/internal/pokeapi/types_locations.go
@@ -10,3 +10,12 @@ type RespShallowLocations struct {
 		URL  string `json:"url"`
 	} `json:"results"`
 }
+
+type Encounters struct {
+	PokemonEncounters []struct {
+		Pokemon struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"pokemon"`
+	} `json:"pokemon_encounters"`
+}

--- a/repl.go
+++ b/repl.go
@@ -27,10 +27,11 @@ func startRepl(cfg *config) {
 		}
 
 		commandName := words[0]
+		args := words[1:]
 
 		command, exists := getCommands()[commandName]
 		if exists {
-			err := command.callback(cfg)
+			err := command.callback(cfg, args)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -51,7 +52,7 @@ func cleanInput(text string) []string {
 type cliCommand struct {
 	name        string
 	description string
-	callback    func(*config) error
+	callback    func(*config, []string) error
 }
 
 func getCommands() map[string]cliCommand {
@@ -75,6 +76,11 @@ func getCommands() map[string]cliCommand {
 			name:        "exit",
 			description: "Exit the Pokedex",
 			callback:    commandExit,
+		},
+		"explore": {
+			name:        "explore",
+			description: "exploring in the area",
+			callback:    commandExplore,
 		},
 	}
 }


### PR DESCRIPTION
- Implement explore command to list Pokémon in a given area
- Wire REPL to pass args to commands and validate usage
- Fetch location-area/<name> via PokeAPI with cache + 404 handling
- Parse pokemon_encounters and print unique names with formatted headers
- Normalize input (trim/lower) and unify callback signature
- Add Encounters type and GetPokemons to pokeapi client
- Cache only successful (200) responses
- Improve messages: “Exploring <area>...”, “Found Pokemon:”, and usage hints

Result: exploring prints a clean list; repeat calls are instant via cache